### PR TITLE
feat: Users#show endpoint

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  def show
+    user = User.find(params[:id])
+    render json: UserSerializer.new(user).serializable_hash.to_json
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer
   include JSONAPI::Serializer
-  attributes :id, :email, :name
+  attributes :id, :email, :name, :books
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,6 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
-  # root "posts#index"
+
+  resources :users, only: [:show]
 end

--- a/entities.md
+++ b/entities.md
@@ -27,6 +27,7 @@ erDiagram
     string external_id
     string title
     string[] authors
+    string thumbnail_url
   }
 
   Club {


### PR DESCRIPTION
Sets up basic Users#show endpoint, with a serializer that includes books data.

In a prod project I would have used a separate books serializer and an includes param here, but keeping things lightweight for speed / demo purposes

**DEMO**
<img width="1081" alt="Screenshot 2024-06-02 at 13 00 14" src="https://github.com/stevebutler2210/ReadMe/assets/25485564/12549738-25bc-48c2-a23c-ea0085bda250">
